### PR TITLE
GRIDBOT-7: Incorrect expiration dates on screenshot utility

### DIFF
--- a/Assemblies/MFDLabs.Grid.Arbiter/Implementation/GridServerArbiter.cs
+++ b/Assemblies/MFDLabs.Grid.Arbiter/Implementation/GridServerArbiter.cs
@@ -1585,8 +1585,6 @@ namespace MFDLabs.Grid
             public void RenewLease()
             {
                 SystemLogger.Singleton.LifecycleEvent("Renewing instance '{0}' lease '{1}', current expiration '{2}'", Name, Lease, Expiration);
-                var t = DateTime.Now.Subtract(_lease);
-                if (t > _expiration) _expiration = t;
                 ScheduleExpirationCheck();
             }
             public void SubscribeExpirationListener(OnExpired @delegate)


### PR DESCRIPTION
There is currently an issue that doesn't break anything, but is quite annoying; when executing a view-console on a grid server, the "time to expire" is incorrect, and behind the current time even.

Example:
![image](https://user-images.githubusercontent.com/79342039/153722314-47698523-73a0-4653-a6e6-a130b76c87ce.png)
[Message sent at 17:24, instance created at 17:24, default lease is 15 minutes]

There is a possible reasoning behind this being the following:
![image](https://user-images.githubusercontent.com/79342039/153722335-4b149e56-07b4-402f-8734-5d3a2e858d89.png)
The RenewLease() method is called inside GridServerInstance.Unlock(), which is called after code is executed. 
This part here is possibly assigning the _expiration field to an incorrect value giving us the massively offset values.




On the branch fix/incorrect-instance-expiration-screenshot-utility, {{}} we are going to work on a fix by removing this section to determine if it is actually this part that is causing it.