### PR TITLE
GRIDBOT-12: Make arbiter re-queue happen on lease expired instead of directly after execution.

### DIFF
--- a/Shared/MFDLabs.GridTasks/WorkQueues/ScriptExecutionWorkQueue.cs
+++ b/Shared/MFDLabs.GridTasks/WorkQueues/ScriptExecutionWorkQueue.cs
@@ -407,19 +407,6 @@ namespace MFDLabs.Grid.Bot.Tasks.WorkQueues
                                 ex.Message
                             );
                         }
-
-#if NETFRAMEWORK
-                        GridServerArbiter.Singleton.BatchQueueUpLeasedArbiteredInstancesUnsafe(
-                            null,
-                            1
-#if DEBUG
-                            ,
-                            5,
-                            "localhost",
-                            false
-#endif
-                        );
-#endif
                     }
                 }
             }

--- a/Shared/MFDLabs.GridUtility/GridServerArbiterScreenshotUtility.cs
+++ b/Shared/MFDLabs.GridUtility/GridServerArbiterScreenshotUtility.cs
@@ -139,6 +139,16 @@ namespace MFDLabs.Grid.Bot.Utility
 
             SavedInstances.TryRemove(instanceKey, out _);
             ScriptReferenceLookupTable.TryRemove(instanceKey, out _);
+            GridServerArbiter.Singleton.BatchQueueUpLeasedArbiteredInstancesUnsafe(
+                null,
+                1
+#if DEBUG
+                ,
+                5,
+                "localhost",
+                false
+#endif
+            );
         }
 
         private static bool CheckIfHasIds(this SocketMessage self, out ICollection<int> d)
@@ -213,9 +223,9 @@ namespace MFDLabs.Grid.Bot.Utility
                 .WithTitle("Your Grid Server Instances");
 
             var text = "";
-            
+
             foreach (var id in ids)
-            { 
+            {
                 var (messageId, jumpUrl) = message.GetInstanceReferenceUrl(id);
                 builder.AddField($"Instance ID {id}", $"[{messageId}]({jumpUrl})", true);
             }


### PR DESCRIPTION
Currently, with script execution we re-queue a leased arbitered instance straight after we execute our code, this is used to have available instances in the future for faster compute:
![image](https://user-images.githubusercontent.com/79342039/153734032-e6d254fb-93dd-4611-9974-8562aab36d1a.png)

While this was OK for non-leased instances, it kind of creates a massive backlog for the grid server arbiter. 

What I propose is that it should be done in `MFDLabs.Grid.Bot.Utility.GridServerArbiterScreenshotUtility.OnLeasedExpired()`