### PR TITLE
GRIDBOT-20 Use MessageReference instead of ping

### DIFF
--- a/Shared/MFDLabs.GridExtensions/Discord/IUserExtensions.cs
+++ b/Shared/MFDLabs.GridExtensions/Discord/IUserExtensions.cs
@@ -111,11 +111,11 @@ namespace MFDLabs.Grid.Bot.Extensions
             var dmChannel = await BotGlobal.Client.GetDMChannelAsync(user.Id);
             if (dmChannel == null) dmChannel = await user.CreateDMChannelAsync();
             return await dmChannel?.SendMessageAsync(
-                $"<@{user.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}",
+                text,
                 isTts,
                 embed,
                 options,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = true },
                 messageReference
             );
         }
@@ -134,12 +134,12 @@ namespace MFDLabs.Grid.Bot.Extensions
             if (dmChannel == null) dmChannel = await user.CreateDMChannelAsync();
             return await dmChannel?.SendFileAsync(
                 fileName,
-                $"<@{user.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}",
+                text,
                 isTts,
                 embed,
                 options,
                 isSpoiler,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = true },
                 messageReference
             );
         }
@@ -160,12 +160,12 @@ namespace MFDLabs.Grid.Bot.Extensions
             return await dmChannel?.SendFileAsync(
                 stream,
                 fileName,
-                $"<@{user.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}",
+                text,
                 isTts,
                 embed,
                 options,
                 isSpoiler,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = true },
                 messageReference
             );
         }

--- a/Shared/MFDLabs.GridExtensions/Discord/SocketCommandBaseExtensions.cs
+++ b/Shared/MFDLabs.GridExtensions/Discord/SocketCommandBaseExtensions.cs
@@ -33,8 +33,6 @@ namespace MFDLabs.Grid.Bot.Extensions
             RequestOptions options = null
         )
         {
-            text = pingUser ? $"<@{command.User.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}" : text;
-
             if (!command.HasResponded)
             {
                 await command.RespondAsync(
@@ -42,7 +40,7 @@ namespace MFDLabs.Grid.Bot.Extensions
                     embeds,
                     isTts,
                     false,
-                    new AllowedMentions(AllowedMentionTypes.Users),
+                    new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                     component,
                     embed,
                     options
@@ -55,7 +53,7 @@ namespace MFDLabs.Grid.Bot.Extensions
                 embeds,
                 isTts,
                 false,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                 component,
                 embed,
                 options
@@ -83,8 +81,6 @@ namespace MFDLabs.Grid.Bot.Extensions
             RequestOptions options = null
         )
         {
-            text = pingUser ? $"<@{command.User.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}" : text;
-
             if (!command.HasResponded)
             {
                 await command.RespondAsync(
@@ -92,7 +88,7 @@ namespace MFDLabs.Grid.Bot.Extensions
                     embeds,
                     isTts,
                     true,
-                    new AllowedMentions(AllowedMentionTypes.Users),
+                    new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                     component,
                     embed,
                     options
@@ -106,7 +102,7 @@ namespace MFDLabs.Grid.Bot.Extensions
                 embeds,
                 isTts,
                 true,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                 component,
                 embed,
                 options
@@ -136,8 +132,6 @@ namespace MFDLabs.Grid.Bot.Extensions
             RequestOptions options = null
         )
         {
-            text = pingUser ? $"<@{command.User.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}" : text;
-
             return await command.FollowupWithFileAsync(
                 fileStream,
                 fileName,
@@ -145,7 +139,7 @@ namespace MFDLabs.Grid.Bot.Extensions
                 embeds,
                 isTts,
                 true,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                 components,
                 embed,
                 options
@@ -177,8 +171,6 @@ namespace MFDLabs.Grid.Bot.Extensions
            RequestOptions options = null
         )
         {
-            text = pingUser ? $"<@{command.User.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}" : text;
-
             return await command.FollowupWithFileAsync(
                 fileStream,
                 fileName,
@@ -186,7 +178,7 @@ namespace MFDLabs.Grid.Bot.Extensions
                 embeds,
                 isTts,
                 false,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                 components,
                 embed,
                 options

--- a/Shared/MFDLabs.GridExtensions/Discord/SocketMessageExtensions.cs
+++ b/Shared/MFDLabs.GridExtensions/Discord/SocketMessageExtensions.cs
@@ -10,65 +10,90 @@ namespace MFDLabs.Grid.Bot.Extensions
 {
     public static class SocketMessageExtensions
     {
-        public static async Task<RestUserMessage> ReplyAsync(this SocketMessage message,
+        public static async Task<RestUserMessage> ReplyAsync(
+            this SocketMessage message,
             string text = null,
             bool isTts = false,
             Embed embed = null,
-            RequestOptions options = null,
-            MessageReference messageReference = null)
-            =>
-                await message.Channel.SendMessageAsync(
-                    $"<@{message.Author.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}",
-                    isTts,
-                    embed,
-                    options,
-                    new AllowedMentions(AllowedMentionTypes.Users),
-                    messageReference);
-        public static async Task<RestUserMessage> ReplyWithFileAsync(this SocketMessage message,
+            RequestOptions options = null
+        )
+        => await message.Channel.SendMessageAsync(
+                text,
+                isTts,
+                embed,
+                options,
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = true },
+                new MessageReference(message.Id)
+            );
+        public static async Task<RestUserMessage> ReplyWithFileAsync(
+            this SocketMessage message,
             string fileName,
             string text = null,
             bool isTts = false,
             Embed embed = null,
             RequestOptions options = null,
-            bool isSpoiler = false,
-            MessageReference messageReference = null)
-            => await message.Channel.SendFileAsync(fileName, $"<@{message.Author.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}", isTts, embed, options, isSpoiler, new AllowedMentions(AllowedMentionTypes.Users), messageReference);
-        public static async Task<RestUserMessage> ReplyWithFileAsync(this SocketMessage message,
+            bool isSpoiler = false
+        )
+            => await message.Channel.SendFileAsync(
+                fileName,
+                text,
+                isTts,
+                embed,
+                options,
+                isSpoiler,
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = true },
+                new MessageReference(message.Id)
+            );
+        public static async Task<RestUserMessage> ReplyWithFileAsync(
+            this SocketMessage message,
             Stream stream,
             string fileName,
             string text = null,
             bool isTts = false,
             Embed embed = null,
             RequestOptions options = null,
-            bool isSpoiler = false,
-            MessageReference messageReference = null)
-            => await message.Channel.SendFileAsync(stream, fileName, $"<@{message.Author.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}", isTts, embed, options, isSpoiler, new AllowedMentions(AllowedMentionTypes.Users), messageReference);
-        public static RestUserMessage ReplyWithFile(this SocketMessage message,
+            bool isSpoiler = false
+        )
+            => await message.Channel.SendFileAsync(
+                stream,
+                fileName,
+                text,
+                isTts,
+                embed,
+                options,
+                isSpoiler,
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = true },
+                new MessageReference(message.Id)
+            );
+        public static RestUserMessage ReplyWithFile(
+            this SocketMessage message,
             string fileName,
             string text = null,
             bool isTts = false,
             Embed embed = null,
             RequestOptions options = null,
-            bool isSpoiler = false,
-            MessageReference messageReference = null)
-            => message.ReplyWithFileAsync(fileName, text, isTts, embed, options, isSpoiler, messageReference).GetAwaiter().GetResult();
-        public static RestUserMessage ReplyWithFile(this SocketMessage message,
+            bool isSpoiler = false
+        )
+            => message.ReplyWithFileAsync(fileName, text, isTts, embed, options, isSpoiler).GetAwaiter().GetResult();
+        public static RestUserMessage ReplyWithFile(
+            this SocketMessage message,
             Stream stream,
             string fileName,
             string text = null,
             bool isTts = false,
             Embed embed = null,
             RequestOptions options = null,
-            bool isSpoiler = false,
-            MessageReference messageReference = null)
-            => message.ReplyWithFileAsync(stream, fileName, text, isTts, embed, options, isSpoiler, messageReference).GetAwaiter().GetResult();
-        public static RestUserMessage Reply(this SocketMessage message,
+            bool isSpoiler = false
+        )
+            => message.ReplyWithFileAsync(stream, fileName, text, isTts, embed, options, isSpoiler).GetAwaiter().GetResult();
+        public static RestUserMessage Reply
+            (this SocketMessage message,
             string text = null,
             bool isTts = false,
             Embed embed = null,
-            RequestOptions options = null,
-            MessageReference messageReference = null)
-            => message.ReplyAsync(text, isTts, embed, options, messageReference).GetAwaiter().GetResult();
+            RequestOptions options = null
+        )
+            => message.ReplyAsync(text, isTts, embed, options).GetAwaiter().GetResult();
         public static bool IsInPublicChannel(this SocketMessage message) =>
             message.Channel is SocketGuildChannel;
         public static async Task<bool> RejectIfNotAdminAsync(this SocketMessage message) 

--- a/Shared/MFDLabs.GridUtility/AdminUtility.cs
+++ b/Shared/MFDLabs.GridUtility/AdminUtility.cs
@@ -17,15 +17,14 @@ namespace MFDLabs.Grid.Bot.Utility
             string text = null,
             bool isTts = false,
             Embed embed = null,
-            RequestOptions options = null,
-            MessageReference messageReference = null)
-            => await message.Channel.SendMessageAsync(
-                    $"<@{message.Author.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}",
+            RequestOptions options = null
+        ) => await message.Channel.SendMessageAsync(
+                    text,
                     isTts,
                     embed,
                     options,
-                    new AllowedMentions(AllowedMentionTypes.Users),
-                    messageReference
+                    new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = true },
+                    new MessageReference(message.Id)
                 );
 
         public static async Task RespondEphemeralAsync(
@@ -39,8 +38,6 @@ namespace MFDLabs.Grid.Bot.Utility
             RequestOptions options = null
         )
         {
-            text = pingUser ? $"<@{command.User.Id}>{(!text.IsNullOrEmpty() ? ", " : "")}{text}" : text;
-
             if (!command.HasResponded)
             {
                 await command.RespondAsync(
@@ -48,7 +45,7 @@ namespace MFDLabs.Grid.Bot.Utility
                     embeds,
                     isTts,
                     true,
-                    new AllowedMentions(AllowedMentionTypes.Users),
+                    new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                     component,
                     embed,
                     options
@@ -61,7 +58,7 @@ namespace MFDLabs.Grid.Bot.Utility
                 embeds,
                 isTts,
                 true,
-                new AllowedMentions(AllowedMentionTypes.Users),
+                new AllowedMentions(AllowedMentionTypes.Users) { MentionRepliedUser = pingUser },
                 component,
                 embed,
                 options


### PR DESCRIPTION
---
name: #27
about: Drop all pings and move to message references, create a new issue if it gets wrong data
title: 'Use MessageReference instead of ping'
labels: 'enhancement'
assignees: 'nkpetko'

---

**Is your pull request related to the project? Please describe.**
Drop all pings and move to message references, create a new issue if it gets wrong data

**Describe how it works**
N/A

**Describe alternatives you've considered**
N/A

**Additional context**
N/A

**Checks and Reviews**
If you have passed all the above, await the actions to complete, and then await reviews to submitted.
