### PR TITLE
GRIDBOT-7: Fix incorrect instance expiration

### DIFF
--- a/Shared/MFDLabs.GridTasks/WorkQueues/GridServerScreenshotWorkQueue.cs
+++ b/Shared/MFDLabs.GridTasks/WorkQueues/GridServerScreenshotWorkQueue.cs
@@ -247,9 +247,7 @@ namespace MFDLabs.Grid.Bot.WorkQueues
                         break;
 
                     case GridServerArbiterScreenshotUtility.ScreenshotStatus.Success:
-                        var expiration = instance.Expiration;
-                        var timeStamp = new DateTimeOffset(expiration).ToUnixTimeSeconds();
-                        message.ReplyWithFile(stream, fileName, $"This instance will expire at <t:{timeStamp}:T>");
+                        message.ReplyWithFile(stream, fileName);
                         break;
 
                     case GridServerArbiterScreenshotUtility.ScreenshotStatus.DisposedInstance:

--- a/Shared/MFDLabs.GridTasks/WorkQueues/ScriptExecutionWorkQueue.cs
+++ b/Shared/MFDLabs.GridTasks/WorkQueues/ScriptExecutionWorkQueue.cs
@@ -322,6 +322,7 @@ namespace MFDLabs.Grid.Bot.WorkQueues
 
 #if NETFRAMEWORK
                     var instance = GridServerArbiter.Singleton.GetOrCreateAvailableLeasedInstance();
+                    var expirationTime = new DateTimeOffset(instance.Expiration).ToUnixTimeSeconds();
 #endif
 
                     try
@@ -334,9 +335,11 @@ namespace MFDLabs.Grid.Bot.WorkQueues
                         instance.Lock();
 
                         message.CreateGridServerInstanceReference(ref instance);
+
 #else
                         var result = LuaUtility.ParseLuaValues(GridServerArbiter.Singleton.BatchJobEx(job, scriptEx));
 #endif
+
 
                         if (!result.IsNullOrEmpty())
                         {
@@ -345,11 +348,20 @@ namespace MFDLabs.Grid.Bot.WorkQueues
                                 _perfmon.TotalItemsProcessedThatHadAFileResult.Increment();
                                 message.ReplyWithFile(new MemoryStream(Encoding.UTF8.GetBytes(result)),
                                     "execute-result.txt",
-                                    "Executed script with return:");
+#if NETFRAMEWORK
+                                $"This instance will expire at <t:{expirationTime}:T>"
+#else
+                                "Executed script with return:"
+#endif
+                                );
                                 return;
                             }
                             message.Reply(
+#if NETFRAMEWORK
+                                $"This instance will expire at <t:{expirationTime}:T>",
+#else
                                 "Executed script with return:",
+#endif
                                 embed: new EmbedBuilder()
                                 .WithTitle("Return value")
                                 .WithDescription($"```\n{result}\n```")
@@ -361,7 +373,12 @@ namespace MFDLabs.Grid.Bot.WorkQueues
 
                             return;
                         }
+
+#if NETFRAMEWORK
+                        message.Reply($"This instance will expire at <t:{expirationTime}:T>");
+#else
                         message.Reply("Executed script with no return!");
+#endif
 
 
                     }
@@ -379,7 +396,10 @@ namespace MFDLabs.Grid.Bot.WorkQueues
                         // We assume that it didn't actually track screenshots here.
                         instance.Lock();
                         message.CreateGridServerInstanceReference(ref instance);
+
+                        message.Reply($"This instance will expire at <t:{expirationTime}:T>");
 #endif
+
 
                         if (ex is not IOException) throw; // rethrow.
                     }


### PR DESCRIPTION
---
name: Pull request
about: This PR fixes an issue with the screenshot utility returning massively offset dates.
title: 'GRIDBOT-7: Fix incorrect instance expiration'
labels: 'bug'
assignees: 'nkpetko'

---

**Is your pull request related to the project? Please describe.**
This PR attempts to fix an issue with expirations on screenshot utility expiration dates with massive offsets

**Describe how it works**
Instead of showing expiration on screenshot, it will show it on execution.

**Describe alternatives you've considered**
Removing the feature entirely.

**Additional context**
![o](https://infrastructure.s3-cdn.vmminfra.net/client-frontend-cdn/petko/DiscordPTB_DgaSLRK2jK.png)
![k](https://cdn.discordapp.com/attachments/862379648024969226/949684595018850455/unknown.png)

**Checks and Reviews**
If you have passed all the above, await the actions to complete, and then await reviews to submitted.
