### PR TITLE
GRIDBOT-23: Fix empty message on maintenace reenabling

### DIFF
--- a/Shared/MFDLabs.GridCommands/Commands/Maintenance.cs
+++ b/Shared/MFDLabs.GridCommands/Commands/Maintenance.cs
@@ -55,6 +55,9 @@ namespace MFDLabs.Grid.Bot.Commands
                         return;
                     }
 
+                    if (optionalMessage.IsNullOrEmpty())
+                        optionalMessage = global::MFDLabs.Grid.Bot.Properties.Settings.Default.ReasonForDying;
+
                     global::MFDLabs.Grid.Bot.Properties.Settings.Default["IsEnabled"] = false;
 
                     global::MFDLabs.Grid.Bot.Global.BotGlobal.Client.SetStatusAsync(UserStatus.DoNotDisturb);

--- a/Shared/MFDLabs.GridCommands/SlashCommands/Maintenance.cs
+++ b/Shared/MFDLabs.GridCommands/SlashCommands/Maintenance.cs
@@ -75,6 +75,9 @@ namespace MFDLabs.Grid.Bot.SlashCommands
                         return;
                     }
 
+                    if (optionalMessage.IsNullOrEmpty())
+                        optionalMessage = global::MFDLabs.Grid.Bot.Properties.Settings.Default.ReasonForDying;
+
                     global::MFDLabs.Grid.Bot.Properties.Settings.Default["IsEnabled"] = false;
 
                     global::MFDLabs.Grid.Bot.Global.BotGlobal.Client.SetStatusAsync(UserStatus.DoNotDisturb);


### PR DESCRIPTION
---
name: Pull request
about: This PR will fix the undefined message when reenabling maintenance.
title: 'GRIDBOT-23: Fix empty message on maintenace reenabling'
labels: 'bug, enhancement'
assignees: 'nkpetko'

---

**Is your pull request related to the project? Please describe.**
This will fix the issue with the maintenance commands where reenabling maintenance without a message will make it display empty text in the user status.

**Describe how it works**
This PR will assign the optional message to the global maintenance message if optional message is empty

**Describe alternatives you've considered**
Not caring.

**Additional context**
Add any other context or screenshots about the pull request here.

**Checks and Reviews**
If you have passed all the above, await the actions to complete, and then await reviews to submitted.
