### PR TITLE
Restrict build workflow to master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/build.yml"
 
     branches:
-      - "**"
+      - "master"
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
At the current state (with deployments and builds available via PR comments) it only makes sense to restrict this to master only as that is all that I am using it for at the moment.